### PR TITLE
Update ESLint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,8 +12,8 @@ module.exports = {
   plugins: ['vue', 'prettier'],
   // add your custom rules here
   rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-console': process.env.NODE_ENV === 'development' ? 'off' : 'error',
+    'no-debugger': process.env.NODE_ENV === 'development' ? 'off' : 'error',
     'import/no-extraneous-dependencies': 'off',
     'import/no-unresolved': 'off',
     'no-await-in-loop': 'off',

--- a/api/server.js
+++ b/api/server.js
@@ -17,10 +17,12 @@ async function start() {
 
   app.listen(PORT, () => {
     if (NODE_ENV === 'development') {
+      /* eslint-disable no-console */
       console.log(`API Server is listening on: http://localhost:${PORT}`);
       swaggerSpecs.forEach(({ version }) => {
         console.log(`API ${version} on: http://localhost:${PORT}/docs/${version}`);
       });
+      /* eslint-enable no-console */
     }
   });
 }


### PR DESCRIPTION
- CircleCI のログに `console.log()` の記述があるのを確認
- pre-commit hook の際にエラーになるよう ESLint の設定を修正
  - Nuxt.js のデフォルトの設定では `NODE_ENV` が `production` の時のみエラー
  - `development` 以外ならエラーになるように修正