### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,38 +1,66 @@
 {
-  "extends": ["config:base"],
-  "assignees": ["hi85gh"],
-  "timezone": "Asia/Tokyo",
-  "schedule": ["every weekend"],
-  "labels": ["renovate"],
-  "patch": { "automerge": true },
+  "extends": [
+    ":ignoreModulesAndTests",
+    ":label(renovate)",
+    ":prConcurrentLimit20",
+    ":prNotPending",
+    ":renovatePrefix",
+    ":timezone(Asia/Tokyo)",
+    "group:monorepos",
+    "helpers:disableTypesNodeMajor"
+  ],
+  "npm": {
+    "extends": [
+      ":automergePatch",
+      ":semanticPrefixFixDepsChoreOthers",
+      ":separatePatchReleases",
+      ":unpublishSafe"
+    ],
+    "rangeStrategy": "bump",
+    "packageRules": [
+      {
+        "groupName": "ESLint",
+        "packageNames": ["babel-eslint"],
+        "packagePatterns": ["^eslint"]
+      },
+      {
+        "description": "automerge minor updates in devDeps",
+        "updateTypes": ["minor"],
+        "depTypeList": ["devDependencies"],
+        "automerge": true,
+        "packageNames": [
+          "codecov",
+          "husky",
+          "jest",
+          "lint-staged",
+          "mongodb-memory-server",
+          "nodemon",
+          "npm-run-all"
+        ],
+        "packagePatterns": ["^chai"]
+      },
+      {
+        "packageNames": ["prettier"],
+        "enabled": false
+      }
+    ]
+  },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 3am on the first day of the month"]
+    "schedule": ["before 9am on the first day of the month"]
   },
-  "packageRules": [
-    {
-      "groupName": "Package for Nuxt.js",
-      "packagePatterns": ["^nuxt", "^@nuxtjs/"]
-    },
-    {
-      "groupName": "Package for API server",
-      "packagePatterns": ["^express", "^swagger"]
-    },
-    {
-      "groupName": "Package for MongoDB",
-      "packagePatterns": ["^mongodb", "^mongoose"]
-    },
-    {
-      "groupName": "Package for Lint",
-      "packagePatterns": ["^babel-eslint", "^eslint", "^husky", "^lint-staged"]
-    },
-    {
-      "groupName": "Package for Testing",
-      "packagePatterns": ["^jest", "^chai", "^codecov"]
-    },
-    {
-      "packagePatterns": ["^prettier"],
-      "enabled": false
-    }
-  ]
+  "circleci": {
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "branch",
+    "schedule": ["before 9am on Friday"],
+    "semanticCommitScope": "docker",
+    "semanticCommitType": "ci",
+    "packageRules": [
+      {
+        "groupName": "Node Docker digests in CircleCI",
+        "packageNames": ["circleci/node", "node"]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
下記の設定を参考にして更新しました。

- [teppeis/renovate-config: My shareable config for @renovateapp](https://github.com/teppeis/renovate-config)
  - `nvmrc` があるので `"helpers:disableTypesNodeMajor"` は `npm.extends` から移動しています。
  - 動作確認のため `npm.schedule` の指定は削除しています。

自動でマージされなかったことについては `"extends": ["config:base"]` に `":automergeDisabled"` の指定があったのが影響していたのかもしれません。
（[Full Config Presets](https://renovatebot.com/docs/presets-config/) をご参照ください。）

- Renovate Docs
  - [Full Config Presets](https://renovatebot.com/docs/presets-config/)
  - [Group Presets](https://renovatebot.com/docs/presets-group/#grouprecommended)
  - [Configuration Options](https://renovatebot.com/docs/configuration-options/#automergetype)
  - [Default Presets](https://renovatebot.com/docs/presets-default/#unpublishsafe)
  - [Helper Presets](https://renovatebot.com/docs/presets-helpers/)
