### PR TITLE
Update lint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,10 +7,8 @@ module.exports = {
   parserOptions: {
     parser: 'babel-eslint',
   },
-  extends: ['airbnb-base', 'plugin:vue/recommended', 'plugin:prettier/recommended'],
-  // required to lint *.vue files
+  extends: ['airbnb-base', 'plugin:vue/essential', 'plugin:prettier/recommended'],
   plugins: ['vue', 'prettier'],
-  // add your custom rules here
   rules: {
     'no-console': process.env.NODE_ENV === 'development' ? 'off' : 'error',
     'no-debugger': process.env.NODE_ENV === 'development' ? 'off' : 'error',

--- a/components/Logo.vue
+++ b/components/Logo.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="VueToNuxtLogo">
-    <div class="Triangle Triangle--two"/>
-    <div class="Triangle Triangle--one"/>
-    <div class="Triangle Triangle--three"/>
-    <div class="Triangle Triangle--four"/>
+    <div class="Triangle Triangle--two" />
+    <div class="Triangle Triangle--one" />
+    <div class="Triangle Triangle--three" />
+    <div class="Triangle Triangle--four" />
   </div>
 </template>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,5 @@
 <template>
-  <div>
-    <nuxt/>
-  </div>
+  <div><nuxt /></div>
 </template>
 
 <style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,8 +4,8 @@ module.exports = {
   mode: 'spa',
 
   /*
-  ** Headers of the page
-  */
+   ** Headers of the page
+   */
   head: {
     title: pkg.name,
     meta: [
@@ -17,41 +17,41 @@ module.exports = {
   },
 
   /*
-  ** Customize the progress-bar color
-  */
+   ** Customize the progress-bar color
+   */
   loading: { color: '#fff' },
 
   /*
-  ** Global CSS
-  */
+   ** Global CSS
+   */
   css: [],
 
   /*
-  ** Plugins to load before mounting the App
-  */
+   ** Plugins to load before mounting the App
+   */
   plugins: [],
 
   /*
-  ** Nuxt.js modules
-  */
+   ** Nuxt.js modules
+   */
   modules: [
     // Doc: https://github.com/nuxt-community/axios-module#usage
     '@nuxtjs/axios',
   ],
   /*
-  ** Axios module configuration
-  */
+   ** Axios module configuration
+   */
   axios: {
     // See https://github.com/nuxt-community/axios-module#options
   },
 
   /*
-  ** Build configuration
-  */
+   ** Build configuration
+   */
   build: {
     /*
-    ** You can extend webpack config here
-    */
+     ** You can extend webpack config here
+     */
     extend(config, ctx) {
       // Run ESLint on save
       if (ctx.isDev && ctx.isClient) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mongodb-memory-server": "2.8.0",
     "nodemon": "1.18.7",
     "npm-run-all": "4.1.5",
-    "prettier": "1.14.3"
+    "prettier": "1.15.3"
   },
   "husky": {
     "hooks": {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,22 +1,12 @@
 <template>
   <section class="container">
     <div>
-      <logo/>
-      <h1 class="title">
-        mugensweeper
-      </h1>
-      <h2 class="subtitle">
-        My glorious Nuxt.js project
-      </h2>
+      <logo />
+      <h1 class="title">mugensweeper</h1>
+      <h2 class="subtitle">My glorious Nuxt.js project</h2>
       <div class="links">
-        <a
-          href="https://nuxtjs.org/"
-          target="_blank"
-          class="button--green">Documentation</a>
-        <a
-          href="https://github.com/nuxt/nuxt.js"
-          target="_blank"
-          class="button--grey">GitHub</a>
+        <a href="https://nuxtjs.org/" target="_blank" class="button--green">Documentation</a>
+        <a href="https://github.com/nuxt/nuxt.js" target="_blank" class="button--grey">GitHub</a>
       </div>
     </div>
   </section>

--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,8 @@
     "rangeStrategy": "bump",
     "packageRules": [
       {
-        "groupName": "ESLint",
-        "packageNames": ["babel-eslint"],
+        "groupName": "Lint & Formatter",
+        "packageNames": ["babel-eslint", "prettier"],
         "packagePatterns": ["^eslint"]
       },
       {
@@ -40,10 +40,6 @@
           "npm-run-all"
         ],
         "packagePatterns": ["^chai"]
-      },
-      {
-        "packageNames": ["prettier"],
-        "enabled": false
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7952,10 +7952,10 @@ prettier@1.13.7:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
   integrity sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==
 
-prettier@1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
-  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+prettier@1.15.3:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
+  integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
 
 pretty-bytes@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
- Prettier のパッケージのバージョン固定を解除
  - Renovate の更新対象にも追加
- `eslint-plugin-vue` の設定を `plugin:vue/recommended` から `plugin:vue/essential` に変更
  - 以下の npm run-script で ESLint と Prettier のコンフリクトがないことを確認
    ```json
    {
      "scripts": {
        "eslint-check": "eslint --print-config . | eslint-config-prettier-check"
      }
    }
    ```
    参考 : [prettier/eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#cli-helper-tool)