### PR TITLE
Update to not format when .vue file is saved

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "html.format.enable": false,
   "javascript.format.enable": false,
-  "prettier.disableLanguages": [],
   "prettier.eslintIntegration": true,
-  "typescript.format.enable": false
+  "typescript.format.enable": false,
+  "[vue]": { "editor.formatOnSave": false }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:client": "nuxt",
     "generate": "nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
+    "format": "npm run lint -- --fix",
     "test": "jest --config api/jest.config.js",
     "test:watch": "npm test -- --watch",
     "test:coverage": "npm test -- --coverage",


### PR DESCRIPTION
Visual Studio Code で拡張機能の `prettier-vscode` を使って `.vue` をフォーマットすると、`npm run dev` でエラーが発生しました。
そのため `.vue` を自動フォーマットの対象外にしたいと思っています。

- `prettier-vscode` では `prettier-eslint` が使用されているため ESLint の設定と異なる動きをしている？
  - [prettier/prettier-vscode: Visual Studio Code extension for Prettier](https://github.com/prettier/prettier-vscode#vscode-eslint-and-tslint-integration)
- `prettier-vscode` で `prettier.disableLanguages` の設定が効かないため、`.vue` にだけ `"editor.formatOnSave": false` を設定

上記に合わせて手動でフォーマットするための npm run-script を追加しました。