### PR TITLE
WIP: Update npm run-script for Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,15 +1,10 @@
 {
   "name": "preview-mugensweeper",
   "description": "",
-  "scripts": {
-  },
-  "env": {
-  },
-  "formation": {
-  },
-  "addons": [
-
-  ],
+  "scripts": {},
+  "env": {},
+  "formation": {},
+  "addons": [],
   "stack": "heroku-18",
   "buildpacks": [
     {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "node": ">=10.13.0"
   },
   "scripts": {
-    "server": "node api/server.js",
+    "start": "node api/server.js",
     "dev": "npm-run-all --parallel dev:*",
-    "dev:api": "nodemon --exec 'npm run server' --config api/nodemon.json",
+    "dev:api": "nodemon --exec 'npm start' --config api/nodemon.json",
     "dev:client": "nuxt",
     "generate": "nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4550,6 +4550,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hasurl@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hasurl/-/hasurl-1.0.0.tgz#e4c619097ae1e8fc906bee904ce47e94f5e1ea37"
+  integrity sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==
+
 he@1.2.x, he@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -9946,6 +9951,14 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+universal-url@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universal-url/-/universal-url-2.0.0.tgz#35e7fc2c3374804905cee67ea289ed3a47669809"
+  integrity sha512-3DLtXdm/G1LQMCnPj+Aw7uDoleQttNHp2g5FnNQKR6cP6taNWS1b/Ehjjx4PVyvejKi3TJyu8iBraKM4q3JQPg==
+  dependencies:
+    hasurl "^1.0.0"
+    whatwg-url "^7.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
## イシューチケット

なし

## 変更点概要

- [Heroku Review Apps](https://devcenter.heroku.com/articles/github-integration-review-apps) の試験導入のため、 API サーバーが `npm start` で起動できるように更新しました。
- `package.json` の `dependencies` と `yarn.lock` で不整合が起きていたため合わせて修正しました。

## 特にレビューをお願いしたい箇所

なし

## 関連 URL

なし
