### PR TITLE
resolveIssue#188

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,7 +10,6 @@
           class="border-x"
           v-for="i in gridY + infinitLine"
           :key="'borderX' + i"
-          x1="0"
           :x2="$window.width"
           :y1="calcBorderPos(i).y"
           :y2="calcBorderPos(i).y"
@@ -22,7 +21,6 @@
           :key="'borderY' + i"
           :x1="calcBorderPos(i).x"
           :x2="calcBorderPos(i).x"
-          y1="0"
           :y2="$window.height"
         />
 


### PR DESCRIPTION
## イシューチケット
#188
（svgでlineを引く際に、オプションの指定を減らせるのでは？ということで、MDNを読みながら動作確認を行いました）

## 調査結果概要
- x1,x2,y1,y2を指定しない場合は、初期値として0が適用される。
- 上記以外のオプションは存在しないため、例えば縦の直線を表現する際に、x=1のみで直線を表現することはできない。（動作確認済）

## 特にレビューをお願いしたい箇所

なし

## 関連 URL

- https://developer.mozilla.org/en-US/docs/Web/SVG/Element/line