### PR TITLE
axiosのリクエストURLを.envを介して設定可能な形式に改修

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,7 @@
 const pkg = require('./package');
+require('dotenv').config();
+
+const { AXIOS_BASE } = process.env;
 
 module.exports = {
   mode: 'spa',
@@ -43,6 +46,7 @@ module.exports = {
    */
   axios: {
     // See https://github.com/nuxt-community/axios-module#options
+    baseURL: AXIOS_BASE || 'http://localhost:10000/dev',
   },
 
   /*

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -3,7 +3,7 @@ import { URLSearchParams } from 'universal-url';
 export default ({ $axios, store }) => {
   $axios.onRequest((config) => {
     /* eslint-disable no-param-reassign */
-    config.url = `http://localhost:10000/dev${config.url}`; // ToDo:ドメインやディレクトリ構成確定後、ハードコーディング部分修正実施
+    config.url = `${config.baseURL}${config.url}`;
     if (typeof config.data === 'object') {
       const params = new URLSearchParams();
       Object.keys(config.data).forEach((key) => params.append(key, config.data[key]));

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,15 +1,6 @@
-import { URLSearchParams } from 'universal-url';
-
 export default ({ $axios, store }) => {
   $axios.onRequest((config) => {
     /* eslint-disable no-param-reassign */
-    config.url = `${config.baseURL}${config.url}`;
-    if (typeof config.data === 'object') {
-      const params = new URLSearchParams();
-      Object.keys(config.data).forEach((key) => params.append(key, config.data[key]));
-      config.data = params.toString();
-      config.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-    }
     if (store.state.token) config.headers.Authorization = store.state.token;
   });
 };


### PR DESCRIPTION
## イシューチケット

#209 

## 変更点概要

- axiosのリクエストURLを.envを介して設定可能な形式にできるよう、
   nuxt.config.jsとplugins/axios.jsを修正

## 特にレビューをお願いしたい箇所

上記意図がスマートに記述できているかという点

## 関連 URL

無し