### PR TITLE
Add CD workflows in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,53 @@
-version: 2
-jobs:
-  test:
+version: 2.1
+
+executors:
+  default:
+    working_directory: ~/repo
     docker:
       - image: circleci/node:10.14
-    working_directory: ~/repo
+
+commands:
+  restore_npm:
     steps:
-      - checkout
       - restore_cache:
-          keys:
-            - yarn-packages-v1-{{ checksum "yarn.lock" }}
-      - run: yarn
+          name: Restore npm dependencies
+          key: yarn-packages-v1-{{ checksum "yarn.lock" }}
+  save_npm:
+    steps:
       - save_cache:
+          name: Cache npm dependencies
+          key: yarn-packages-v1-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
-          key: yarn-packages-v1-{{ checksum "yarn.lock" }}
-      - run: yarn lint
-      - run: yarn test:coverage --runInBand
+
+jobs:
+  test:
+    executor:
+      name: default
+    steps:
+      - checkout
+      - restore_npm
       - run:
-          name: Test with current Node.js version
-          command: npx --package node@^11 node ./node_modules/.bin/jest --config api/jest.config.js  --runInBand
+          name: Install npm dependencies
+          command: yarn
+      - save_npm
+      - run:
+          name: Run lint
+          command: yarn lint
+      - run:
+          name: Run test
+          command: yarn test:coverage --runInBand
+      - run:
+          name: Run test with current Node.js version
+          command: npx --package node@^11 node ./node_modules/.bin/jest --config api/jest.config.js --runInBand
       - run:
           name: Run a security audit
           command: yarn audit
-      - run: yarn coverage
+      - run:
+          name: Report coverage results
+          command: yarn coverage
 
 workflows:
-  version: 2
   test_and_deploy:
     jobs:
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,27 @@ executors:
   default:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:10.14
+      - image: circleci/node:10.15
+        environment:
+          TZ: Asia/Tokyo
 
 commands:
+  restore_repo:
+    steps:
+      - restore_cache:
+          name: Restore repository
+          key: repo-v1-{{ .Environment.CIRCLE_SHA1 }}
+  save_repo:
+    steps:
+      - checkout
+      - run:
+          name: Make Shell Script executable
+          command: chmod a+x ./.circleci/webhook.sh
+      - save_cache:
+          name: Cache repository
+          key: repo-v1-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/repo
   restore_npm:
     steps:
       - restore_cache:
@@ -19,13 +37,37 @@ commands:
           key: yarn-packages-v1-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+  setup_awscli:
+    steps:
+      - run:
+          name: Install AWS CLI
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y awscli
+  notify_deployment_failed:
+    steps:
+      - run:
+          name: Notify deployment failed
+          command: ./.circleci/webhook.sh
+          environment:
+            DEPLOY_RESULT: failed
+            WEBHOOK_COLOR: "#d10c20"
+          when: on_fail
+  notify_deployment_succeeded:
+    steps:
+      - run:
+          name: Notify deployment succeeded
+          command: ./.circleci/webhook.sh
+          environment:
+            DEPLOY_RESULT: succeeded
+            WEBHOOK_COLOR: "#41aa58"
 
 jobs:
   test:
     executor:
       name: default
     steps:
-      - checkout
+      - save_repo
       - restore_npm
       - run:
           name: Install npm dependencies
@@ -46,8 +88,56 @@ jobs:
       - run:
           name: Report coverage results
           command: yarn coverage
+  deploy_api:
+    executor:
+      name: default
+    environment:
+      DEPLOY_ENV: api
+    steps:
+      - restore_repo
+      - setup_awscli
+      - run:
+          name: Deploy API server
+          command: |
+            [ $CIRCLE_BRANCH = "master" ] && group=$AWS_PROD_GROUP || group=$AWS_STG_GROUP
+            aws deploy create-deployment --application-name $AWS_APP_NAME --deployment-group-name $group \
+            --github-location repository="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME",commitId="$CIRCLE_SHA1"
+      - notify_deployment_failed
+      - notify_deployment_succeeded
+  deploy_web:
+    executor:
+      name: default
+    environment:
+      DEPLOY_ENV: web
+    steps:
+      - restore_repo
+      - restore_npm
+      - run:
+          name: Generate static files
+          command: yarn generate
+      - setup_awscli
+      - run:
+          name: Deploy static files
+          command: aws s3 sync dist s3://$AWS_BUCKET --delete
+      - notify_deployment_failed
+      - notify_deployment_succeeded
 
 workflows:
   test_and_deploy:
     jobs:
       - test
+      - deploy_api:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+      - deploy_web:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/webhook.sh
+++ b/.circleci/webhook.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+if [ $CIRCLE_BRANCH = "master" ]; then
+  DEPLOY_DEST="Production"
+  if [ $DEPLOY_ENV = "web" ]; then
+    DEPLOY_URL=$DEPLOY_WEB_PROD_URL
+  elif [ $DEPLOY_ENV = "api" ]; then
+    DEPLOY_URL=$DEPLOY_API_PROD_URL
+  fi
+else
+  DEPLOY_DEST="Staging"
+  if [ $DEPLOY_ENV = "web" ]; then
+    DEPLOY_URL=$DEPLOY_WEB_STG_URL
+  elif [ $DEPLOY_ENV = "api" ]; then
+    DEPLOY_URL=$DEPLOY_API_STG_URL
+  fi
+fi
+
+if [ $DEPLOY_RESULT = "succeeded" ]; then
+  WEBHOOK_MESSAGE="Successful deploy of $DEPLOY_ENV server ($DEPLOY_DEST)\n$DEPLOY_URL"
+else
+  WEBHOOK_MESSAGE="Something went wrong deploying $CIRCLE_PROJECT_REPONAME ($DEPLOY_DEST)\nFailed <$CIRCLE_BUILD_URL|$CIRCLE_JOB>"
+fi
+
+if [ ${CIRCLECI} ]; then
+  curl -X POST --data-urlencode \
+    'payload={
+      "attachments": [
+        {
+          "color": "'${WEBHOOK_COLOR}'",
+          "text": "'"$WEBHOOK_MESSAGE"'"
+        }
+      ]
+    }' \
+  ${WEBHOOK_URL}
+fi

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,14 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ec2-user/mugensweeper
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ec2-user
+    group: ec2-user
+hooks:
+  ValidateService:
+    - location: deploy.sh
+      runas: ec2-user

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd /home/ec2-user/mugensweeper
+yarn
+yarn start


### PR DESCRIPTION
## イシューチケット

なし

## 変更点概要

- `.circleci/config.yml` の `version` を `2` から `2.1` に更新
- `.circleci/config.yml` に deploy workflow を追加
  - `deploy_api`: `master`, `develop` ブランチの時だけ API サーバーをデプロイ
  - `deploy_web`: `master` ブランチの時だけ AWS S3 に静的ファイルをデプロイ
- deploy success / failed の結果を Discord へ通知
  - URL の通知には以下の環境変数が利用可能
    - `DEPLOY_WEB_PROD_URL`: S3 本番環境
    - `DEPLOY_WEB_STG_URL `: 未使用
    - `DEPLOY_API_PROD_URL`: API サーバー本番環境
    - `DEPLOY_API_STG_URL `:  API サーバーステージング環境
  - 記事の多い Slack の Incoming Webhooks を参考に `.circleci/webhook.sh` を作成
    -  `WEBHOOK_URL`: Slack との互換機能を利用するため Discord の WEBHOOK URL に `/slack` を追加して登録
- `appspec.yml`, `deploy.sh` ファイル追加 
  - [iReversi](https://github.com/ireversi/ireversi) に倣って追加

## 特にレビューをお願いしたい箇所

AWS CLI に関連すると思われる環境変数、ファイルは [iReversi](https://github.com/ireversi/ireversi) を参照していますが、問題ないか確認をお願いします。

## 関連 URL

なし