### PR TITLE
新規データベースでユーザーを作成した際にuserIdが空のレスポンスになるバグを修正しました。

### DIFF
--- a/api/models/v1/userStore.js
+++ b/api/models/v1/userStore.js
@@ -22,10 +22,14 @@ module.exports = {
 
   async addUser(userName) {
     // ユニークな8桁のIDを生成
-    let userId = '';
-    const find = (v) => v.userId === userId;
-    while (users.find(find)) {
-      userId = getHash.generateHash(option);
+    let userId = getHash.generateHash(option);
+
+    for (let i = 0; i < users.length; i += 1) {
+      // 既存のuserIdと重複しているかチェック
+      if (users[i].userId === userId) {
+        userId = getHash.generateHash(option); // 既存と重複しているためuserIdを再生成
+        i = 0; // 新しいuserIdを使って、再びループ処理を実行できるようカウンタ変数を初期化
+      }
     }
 
     const userData = { userName, userId };

--- a/api/tests/routes/v1/user/user.test.js
+++ b/api/tests/routes/v1/user/user.test.js
@@ -1,5 +1,4 @@
 const chai = require('chai');
-const getHash = require('random-hash');
 const app = require('../../../../routes/app.js');
 const { initUser, getUser, addUser } = require('../../../../models/v1/userStore.js');
 const { connectDB, disconnectDB, dropDB } = require('../../../../database.js');
@@ -74,29 +73,20 @@ describe('ユーザー情報を返せるかどうか', () => {
   });
 
   it('新規に生成したuserIdが、既存のuserIdと重複していないか確認', async () => {
-    // Given
-    const option = {
-      length: 7,
-      charset: 'abcdefghijklmnopqrstuvw123456789',
-    };
-
-    // When
-    const users = [];
+    const userIds = [];
     for (let i = 0; i < 100; i += 1) {
-      const userName = getHash.generateHash(option);
-      const { body } = await chai
+      // When
+      const {
+        body: { userId },
+      } = await chai
         .request(app)
         .post('/v1/user')
         .set('content-type', 'application/x-www-form-urlencoded')
-        .send({ userName });
-      users.push(body);
-    }
+        .send({ userName: 'test' });
 
-    // Then
-    for (let s = 0; s < 100; s += 1) {
-      for (let t = s + 1; t < 100; t += 1) {
-        expect(users[s].userId).not.toBe(users[t].userId);
-      }
+      // Then
+      expect(userIds).not.toContain(userId);
+      userIds.push(userId);
     }
   });
 });


### PR DESCRIPTION
## イシューチケット

#332 

## 変更点概要

- userId生成に絡むテストにuserIdが必ず8桁である事、既存のuserIdと重複しない事、
  を確認するロジックを追記しました。
- userStore.jsのaddUser関数内において、userIdを初期値として設定するようにしました。
- userIdの重複確認ロジックを修正しました。

## 特にレビューをお願いしたい箇所

伊藤さんの気にされていた挙動

## 関連 URL

無し