### PR TITLE
Update Renovate configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   default:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:10.15
+      - image: circleci/node:10.15.1
         environment:
           TZ: Asia/Tokyo
 

--- a/renovate.json
+++ b/renovate.json
@@ -11,13 +11,12 @@
   ],
   "npm": {
     "extends": [
-      ":automergePatch",
       ":noUnscheduledUpdates",
       ":semanticPrefixFixDepsChoreOthers",
       ":separatePatchReleases",
       ":unpublishSafe"
     ],
-    "schedule": ["after 9pm", "before 9am"],
+    "schedule": ["every weekend"],
     "rangeStrategy": "bump",
     "packageRules": [
       {
@@ -26,20 +25,9 @@
         "packagePatterns": ["^eslint"]
       },
       {
-        "description": "automerge minor updates in devDeps",
-        "updateTypes": ["minor"],
-        "depTypeList": ["devDependencies"],
-        "automerge": true,
-        "packageNames": [
-          "codecov",
-          "husky",
-          "jest",
-          "lint-staged",
-          "mongodb-memory-server",
-          "nodemon",
-          "npm-run-all"
-        ],
-        "packagePatterns": ["^chai"]
+        "groupName": "MongoDB",
+        "packageNames": ["mongoose"],
+        "packagePatterns": ["^mongodb"]
       }
     ]
   },
@@ -47,21 +35,15 @@
     "enabled": true,
     "schedule": ["before 9am on the first day of the month"]
   },
-  "node": {
-    "enabled": true,
-    "schedule": ["before 9am on Monday"]
-  },
   "circleci": {
     "enabled": true,
-    "automerge": true,
-    "automergeType": "branch",
-    "schedule": ["before 9am on Friday"],
+    "schedule": ["every weekend"],
     "semanticCommitScope": "docker",
     "semanticCommitType": "ci",
     "packageRules": [
       {
         "groupName": "Node Docker digests in CircleCI",
-        "packageNames": ["circleci/node", "node"]
+        "packageNames": ["circleci/node"]
       }
     ]
   }


### PR DESCRIPTION
## イシューチケット

なし

## 変更点概要

- プルリクエストのマージの必須条件にレビューがあり Renovate の `automerge` が無効になるため関連の設定を削除
- 更新スケジュールを週末のみに変更
- CircleCI で使用する Docker のイメージにもパッチバージョンの更新が入るようバージョンの指定を修正

## 特にレビューをお願いしたい箇所

なし

## 関連 URL

なし
